### PR TITLE
Fix GrisuException.getMessage() when _errors is empty

### DIFF
--- a/src/main/java/io/grisu/core/exceptions/GrisuException.java
+++ b/src/main/java/io/grisu/core/exceptions/GrisuException.java
@@ -53,7 +53,7 @@ public class GrisuException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        if (_errors != null) {
+        if (_errors != null && !_errors.isEmpty()) {
             return _errors.toString();
         }
         return "no provided errors";

--- a/src/test/java/io/grisu/core/exceptions/GrisuExceptionTest.java
+++ b/src/test/java/io/grisu/core/exceptions/GrisuExceptionTest.java
@@ -1,0 +1,53 @@
+package io.grisu.core.exceptions;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class GrisuExceptionTest {
+    static class ObjectWithToString {
+        String prop1;
+        Double prop2;
+
+        public ObjectWithToString(String prop1, Double prop2) {
+            this.prop1 = prop1;
+            this.prop2 = prop2;
+        }
+
+        @Override
+        public String toString() {
+            return "ObjectWithToString{" +
+                "prop1='" + prop1 + '\'' +
+                ", prop2=" + prop2 +
+                '}';
+        }
+    }
+
+    @Test
+    public void getMessage_nullErrors() {
+        GrisuException gex = new GrisuException(123, "errorMessage", (Map<String, Object>) null);
+        assertEquals("no provided errors", gex.getMessage());
+    }
+
+    @Test
+    public void getMessage_emptyErrors() {
+        GrisuException gex = new GrisuException(123, "errorMessage", new HashMap<>());
+        assertEquals("no provided errors", gex.getMessage());
+    }
+
+    @Test
+    public void getMessage_withErrors() {
+        Map<String, Object> errors = new HashMap<>();
+        errors.put("stringError", "error one");
+        errors.put("objectError", new ObjectWithToString("prop2", 123.45));
+
+        GrisuException gex = new GrisuException(123, "errorMessage", errors);
+        String message = gex.getMessage();
+
+        assertTrue(message.contains("stringError=error one"));
+        assertTrue(message.contains("objectError=ObjectWithToString{prop1='prop2', prop2=123.45}"));
+    }
+}


### PR DESCRIPTION
When _errors Map is empty, it should show default message
instead of calling toString() on an empty map